### PR TITLE
petalinux: Move she-bang to first line in trd-pl-cfg

### DIFF
--- a/petalinux/xilinx-vck190-base-trd/trd-pl-cfg
+++ b/petalinux/xilinx-vck190-base-trd/trd-pl-cfg
@@ -1,7 +1,7 @@
+#!/bin/bash
+
 # (C) Copyright 2020 - 2021 Xilinx, Inc.
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 SUP_PLATFORMS="vck190_es1_mipiRxQuad_hdmiTx vck190_hdmiRx_hdmiTx vck190_mipiRxSingle_hdmiTx vck190_es1_hdmiRx_hdmiTx vck190_es1_mipiRxSingle_hdmiTx vck190_mipiRxQuad_hdmiTx"
 


### PR DESCRIPTION
Move the she-bang to the first line of the trd-pl-cfg script, otherwise it
doesn't take effect.